### PR TITLE
Precompute M

### DIFF
--- a/cpp/include/deriv.h
+++ b/cpp/include/deriv.h
@@ -1,10 +1,8 @@
 #pragma once
 
+#include "cones.h"
 #include "eigen_includes.h"
 #include "linop.h"
-#include "cones.h"
 
-Vector _solve_derivative(const SparseMatrix& Q, const std::vector<Cone>& cones,
-    const Vector& u, const Vector& v, double w, const Vector& rhs);
-Vector _solve_adjoint_derivative(const SparseMatrix& Q, const std::vector<Cone>& cones,
-    const Vector& u, const Vector& v, double w, const Vector& dz);
+LinearOperator M_operator(const SparseMatrix &Q, const std::vector<Cone> &cones,
+                          const Vector &u, const Vector &v, double w);

--- a/cpp/include/linop.h
+++ b/cpp/include/linop.h
@@ -19,13 +19,15 @@ public:
   explicit LinearOperator(int rows, int cols, const VecFn &matvec_in,
                           const VecFn &rmatvec_in)
       : m(rows), n(cols), matvec(matvec_in), rmatvec(rmatvec_in){};
-  LinearOperator operator+(const LinearOperator &obj);
-  LinearOperator operator-(const LinearOperator &obj);
-  LinearOperator operator*(const LinearOperator &obj);
-  LinearOperator transpose() { return LinearOperator(n, m, rmatvec, matvec); }
+  LinearOperator operator+(const LinearOperator &obj) const;
+  LinearOperator operator-(const LinearOperator &obj) const;
+  LinearOperator operator*(const LinearOperator &obj) const;
+  LinearOperator transpose() const {
+    return LinearOperator(n, m, rmatvec, matvec);
+  }
 
-  Vector apply_matvec(const Vector &x) { return matvec(x); }
-  Vector apply_rmatvec(const Vector &x) { return rmatvec(x); }
+  Vector apply_matvec(const Vector &x) const { return matvec(x); }
+  Vector apply_rmatvec(const Vector &x) const { return rmatvec(x); }
 };
 
 LinearOperator block_diag(const std::vector<LinearOperator> &linear_operators);

--- a/cpp/src/deriv.cpp
+++ b/cpp/src/deriv.cpp
@@ -20,26 +20,9 @@ LinearOperator dpi(const Vector &u, const Vector &v, double w,
   return block_diag(linops);
 }
 
-Vector _solve_derivative(const SparseMatrix &Q, const std::vector<Cone> &cones,
-                         const Vector &u, const Vector &v, double w,
-                         const Vector &rhs) {
+LinearOperator M_operator(const SparseMatrix &Q, const std::vector<Cone> &cones,
+                          const Vector &u, const Vector &v, double w) {
   int N = u.size() + v.size() + 1;
-
-  LinearOperator M =
-      (aslinearoperator(Q) - identity(N)) * dpi(u, v, w, cones) + identity(N);
-  LsqrResult result = lsqr(M, rhs);
-  return result.x;
-}
-
-Vector _solve_adjoint_derivative(const SparseMatrix &Q,
-                                 const std::vector<Cone> &cones,
-                                 const Vector &u, const Vector &v, double w,
-                                 const Vector &dz) {
-  int N = u.size() + v.size() + 1;
-
-  LinearOperator MT = dpi(u, v, w, cones).transpose() *
-                          (aslinearoperator(Q).transpose() - identity(N)) +
-                      identity(N);
-  LsqrResult result = lsqr(MT, dz);
-  return result.x;
+  return (aslinearoperator(Q) - identity(N)) * dpi(u, v, w, cones) +
+         identity(N);
 }

--- a/cpp/src/linop.cpp
+++ b/cpp/src/linop.cpp
@@ -1,7 +1,7 @@
 #include "linop.h"
 #include <assert.h>
 
-LinearOperator LinearOperator::operator+(const LinearOperator &obj) {
+LinearOperator LinearOperator::operator+(const LinearOperator &obj) const {
   assert(m == obj.m);
   assert(n == obj.n);
 
@@ -15,7 +15,7 @@ LinearOperator LinearOperator::operator+(const LinearOperator &obj) {
   return LinearOperator(m, n, result_matvec, result_rmatvec);
 }
 
-LinearOperator LinearOperator::operator-(const LinearOperator &obj) {
+LinearOperator LinearOperator::operator-(const LinearOperator &obj) const {
   assert(m == obj.m);
   assert(n == obj.n);
 
@@ -29,7 +29,7 @@ LinearOperator LinearOperator::operator-(const LinearOperator &obj) {
   return LinearOperator(m, n, result_matvec, result_rmatvec);
 }
 
-LinearOperator LinearOperator::operator*(const LinearOperator &obj) {
+LinearOperator LinearOperator::operator*(const LinearOperator &obj) const {
   assert(n == obj.m);
 
   const LinearOperator this_op = *this;
@@ -53,8 +53,8 @@ LinearOperator block_diag(const std::vector<LinearOperator> &linear_operators) {
     cols += linop.n;
   }
 
-  const VecFn result_matvec = [linear_operators,
-                               rows, cols](const Vector &x) -> Vector {
+  const VecFn result_matvec = [linear_operators, rows,
+                               cols](const Vector &x) -> Vector {
     assert(x.size() == cols);
     Vector out = Vector::Zero(rows);
     int i = 0;
@@ -66,8 +66,8 @@ LinearOperator block_diag(const std::vector<LinearOperator> &linear_operators) {
     }
     return out;
   };
-  const VecFn result_rmatvec = [linear_operators,
-                                rows, cols](const Vector &x) -> Vector {
+  const VecFn result_rmatvec = [linear_operators, rows,
+                                cols](const Vector &x) -> Vector {
     assert(x.size() == rows);
     Vector out = Vector::Zero(cols);
     int i = 0;
@@ -83,7 +83,7 @@ LinearOperator block_diag(const std::vector<LinearOperator> &linear_operators) {
   return LinearOperator(rows, cols, result_matvec, result_rmatvec);
 }
 
-LinearOperator aslinearoperator(const Matrix& A) {
+LinearOperator aslinearoperator(const Matrix &A) {
   const VecFn result_matvec = [A](const Vector &x) -> Vector { return A * x; };
   const VecFn result_rmatvec = [A](const Vector &x) -> Vector {
     return A.transpose() * x;
@@ -91,9 +91,11 @@ LinearOperator aslinearoperator(const Matrix& A) {
   return LinearOperator(A.rows(), A.cols(), result_matvec, result_rmatvec);
 }
 
-LinearOperator aslinearoperator(const SparseMatrix& A) {
-  const VecFn result_matvec = [A](const Vector &x) -> Vector { return A*x; };
-  const VecFn result_rmatvec = [A](const Vector &x) -> Vector { return A.transpose()*x; };
+LinearOperator aslinearoperator(const SparseMatrix &A) {
+  const VecFn result_matvec = [A](const Vector &x) -> Vector { return A * x; };
+  const VecFn result_rmatvec = [A](const Vector &x) -> Vector {
+    return A.transpose() * x;
+  };
   return LinearOperator(A.rows(), A.cols(), result_matvec, result_rmatvec);
 }
 

--- a/cpp/src/wrapper.cpp
+++ b/cpp/src/wrapper.cpp
@@ -14,7 +14,8 @@ PYBIND11_MODULE(_diffcp, m) {
 
   py::class_<LinearOperator>(m, "LinearOperator")
       .def("matvec", &LinearOperator::apply_matvec)
-      .def("rmatvec", &LinearOperator::apply_rmatvec);
+      .def("rmatvec", &LinearOperator::apply_rmatvec)
+      .def("transpose", &LinearOperator::transpose);
   py::class_<Cone>(m, "Cone")
       .def(py::init<ConeType, const std::vector<int> &>())
       .def_readonly("type", &Cone::type)
@@ -25,8 +26,15 @@ PYBIND11_MODULE(_diffcp, m) {
       .value("SOC", ConeType::SOC)
       .value("PSD", ConeType::PSD)
       .value("EXP", ConeType::EXP);
-  m.def("_solve_derivative", &_solve_derivative);
-  m.def("_solve_adjoint_derivative", &_solve_adjoint_derivative);
+
+  m.def("M_operator", &M_operator);
+  py::class_<LsqrResult>(m, "LsqrResult")
+      .def_readonly("solution", &LsqrResult::x);
+  m.def("lsqr", &lsqr, "Computes least-squares solution via LSQR", py::arg("A"),
+        py::arg("rhs"), py::arg("damp") = 0.0, py::arg("atol") = 1e-8,
+        py::arg("btol") = 1e-8, py::arg("conlim") = 1e8,
+        py::arg("iter_lim") = -1);
+
   m.def("dprojection", &dprojection);
   m.def("project_exp_cone", &project_exp_cone);
   m.def("in_exp", &in_exp);


### PR DESCRIPTION
Don't recompute `M` on every derivative application

- compute M before forming the callables `derivative` and `adjoint_derivative`
- expose c++ lsqr function to python
- call LSQR directly with M in Python
- remove _solve_derivative and _solve_derivative_adjoint (these functions just call lsqr)
- add const qualifiers to methods in LinearOperator
- apply clang-format everywhere