### PR TITLE
Fixing "discarding imaginary part" errors

### DIFF
--- a/diffcp/cones.py
+++ b/diffcp/cones.py
@@ -100,7 +100,7 @@ def _proj(x, cone, dual=False):
     elif cone == PSD:
         dim = psd_dim(x.size)
         X = unvec_symm(x, dim)
-        lambd, Q = np.linalg.eig(X)
+        lambd, Q = np.linalg.eigh(X)
         return vec_symm(Q @ sparse.diags(np.maximum(lambd, 0)) @ Q.T)
     elif cone == EXP:
         num_cones = int(x.size / 3)

--- a/setup.py
+++ b/setup.py
@@ -100,8 +100,7 @@ setup(
         "scs >= 2.0.2",  # 2.0.2 is the oldest version on conda forge
         "scipy >= 1.1.0",
         "pybind11 >= 2.4",
-        "threadpoolctl >= 1.1",
-        "cvxpy >= 1.1.0a1"],
+        "threadpoolctl >= 1.1"],
     url="http://github.com/cvxgrp/diffcp/",
     ext_modules=ext_modules,
     license="Apache License, Version 2.0",

--- a/setup.py
+++ b/setup.py
@@ -100,7 +100,8 @@ setup(
         "scs >= 2.0.2",  # 2.0.2 is the oldest version on conda forge
         "scipy >= 1.1.0",
         "pybind11 >= 2.4",
-        "threadpoolctl >= 1.1"],
+        "threadpoolctl >= 1.1",
+	"cvxpy >= 1.0"],
     url="http://github.com/cvxgrp/diffcp/",
     ext_modules=ext_modules,
     license="Apache License, Version 2.0",

--- a/setup.py
+++ b/setup.py
@@ -101,7 +101,7 @@ setup(
         "scipy >= 1.1.0",
         "pybind11 >= 2.4",
         "threadpoolctl >= 1.1",
-	"cvxpy >= 1.0"],
+        "cvxpy >= 1.1.0a1"],
     url="http://github.com/cvxgrp/diffcp/",
     ext_modules=ext_modules,
     license="Apache License, Version 2.0",


### PR DESCRIPTION
Fixes common error when running `diffcp`:
```
diffcp/cones.py:142: ComplexWarning: Casting complex values to real discards the imaginary part
  x[offset:offset + dim], cone, dual=dual)
```
by changing the general eigendecomposition `np.linalg.eig` to the Hermitian eigendecomposition `np.linalg.eigh`. Should also make the code slightly faster and more stable.