### PR TITLE
Expose dpi from C++ to Python

### DIFF
--- a/cpp/include/deriv.h
+++ b/cpp/include/deriv.h
@@ -4,6 +4,12 @@
 #include "eigen_includes.h"
 #include "linop.h"
 
+LinearOperator dpi(const Vector &u, const Vector &v, double w,
+                   const std::vector<Cone> &cones);
+
+Matrix dpi_dense(const Vector &u, const Vector &v, double w,
+                 const std::vector<Cone> &cones);
+
 LinearOperator M_operator(const SparseMatrix &Q, const std::vector<Cone> &cones,
                           const Vector &u, const Vector &v, double w);
 

--- a/cpp/src/wrapper.cpp
+++ b/cpp/src/wrapper.cpp
@@ -47,8 +47,10 @@ PYBIND11_MODULE(_diffcp, m) {
   m.def("_solve_derivative_dense", &_solve_derivative_dense, py::call_guard<py::gil_scoped_release>());
   m.def("_solve_adjoint_derivative_dense", &_solve_adjoint_derivative_dense, py::call_guard<py::gil_scoped_release>());
 
-  m.def("dprojection", &dprojection);
-  m.def("dprojection_dense", &dprojection_dense);
+  m.def("dprojection", &dprojection, py::call_guard<py::gil_scoped_release>());
+  m.def("dprojection_dense", &dprojection_dense, py::call_guard<py::gil_scoped_release>());
+  m.def("dpi", &dpi, py::call_guard<py::gil_scoped_release>());
+  m.def("dpi_dense", &dpi_dense, py::call_guard<py::gil_scoped_release>());
   m.def("project_exp_cone", &project_exp_cone);
   m.def("in_exp", &in_exp);
   m.def("in_exp_dual", &in_exp_dual);


### PR DESCRIPTION
Hi, this is nice to have in Python for convenience sometimes, what do you think about exposing it? If you prefer keeping the API more compact I'm fine if you close this PR without merging this -- in my use case I can just wrap `dprojection` with a scipy linop.