### PR TITLE
Pass openmp flag to linker

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,8 @@ _diffcp = Extension(
             "cpp/include",
         ],
         language='c++',
-        extra_compile_args=["-O3", "-std=c++11"] + openmp() + march_native()
+        extra_compile_args=["-O3", "-std=c++11"] + openmp() + march_native(),
+        extra_link_args=openmp()
 )
 
 def is_platform_mac():


### PR DESCRIPTION
On Ubuntu 20.04, if -fopenmp is passed when compiling but not when
linking, importing diffcp results in the following error

>>> import diffcp
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/akshay/src/cvxgrp/diffcp/diffcp/__init__.py", line 3, in
<module>
    from diffcp.cone_program import solve_and_derivative, \
  File "/home/akshay/src/cvxgrp/diffcp/diffcp/cone_program.py", line 3,
in <module>
    import diffcp.cones as cone_lib
  File "/home/akshay/src/cvxgrp/diffcp/diffcp/cones.py", line 6, in
<module>
    from _diffcp import dprojection, project_exp_cone, Cone, ConeType
ImportError:
/home/akshay/envs/diffcp/lib/python3.8/site-packages/_diffcp.cpython-38-x86_64-linux-gnu.so:
undefined symbol: omp_get_thread_num