### PR TITLE
added ECOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ You will need a C++11-capable compiler to build `diffcp`.
 * [SCS](https://github.com/bodono/scs-python) >= 2.0.2
 * [pybind11](https://github.com/pybind/pybind11/tree/stable) >= 2.4
 * [threadpoolctl](https://github.com/joblib/threadpoolctl) >= 1.1
+* [ECOS](https://github.com/embotech/ecos-python)
 * Python 3.x
 
 `diffcp` uses Eigen; Eigen operations can be automatically vectorized by compilers. To enable vectorization, install with
@@ -65,15 +66,17 @@ with dual variable `y`.
 `diffcp` exposes the function
 
 ```python
-solve_and_derivative(A, b, c, cone_dict, warm_start=None, **kwargs).
+solve_and_derivative(A, b, c, cone_dict, warm_start=None, solver=None, **kwargs).
 ```
 
 This function returns a primal-dual solution `x`, `y`, and `s`, along with
 functions for evaluating the derivative and its adjoint (transpose).
 These functions respectively compute right and left multiplication of the derivative
 of the solution map at `A`, `b`, and `c` by a vector.
-In the case that the problem is not solved, i.e. SCS returns something
-other than "Solved" or "Solved/Innacurate" for status, we raise
+THe `solver` argument determines which solver to use; the available solvers
+are `solver="SCS"` and `solver="ECOS"`.
+If no solver is specified, `diffcp` will choose the solver itself.
+In the case that the problem is not solved, i.e. the solver fails for some reason, we will raise
 a `SolverError` Exception.
 
 #### Arguments
@@ -81,8 +84,8 @@ The arguments `A`, `b`, and `c` correspond to the problem data of a cone program
 * `A` must be a [SciPy sparse CSC matrix](https://docs.scipy.org/doc/scipy/reference/generated/scipy.sparse.csc_matrix.html).
 * `b` and `c` must be NumPy arrays.
 * `cone_dict` is a dictionary that defines the convex cone `K`.
-* `warm_start` is an optional tuple `(x, y, s)` at which to warm-start SCS.
-* `**kwargs` are keyword arguments to forward to SCS (e.g., `verbose=True`).
+* `warm_start` is an optional tuple `(x, y, s)` at which to warm-start. (Note: this is only available for the SCS solver).
+* `**kwargs` are keyword arguments to forward to the solver (e.g., `verbose=False`).
 
 These inputs must conform to the [SCS convention](https://github.com/bodono/scs-python) for problem data. The keys in `cone_dict` correspond to the cones, with
 * `diffcp.ZERO` for the zero cone,

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ This function returns a primal-dual solution `x`, `y`, and `s`, along with
 functions for evaluating the derivative and its adjoint (transpose).
 These functions respectively compute right and left multiplication of the derivative
 of the solution map at `A`, `b`, and `c` by a vector.
-THe `solver` argument determines which solver to use; the available solvers
+The `solver` argument determines which solver to use; the available solvers
 are `solver="SCS"` and `solver="ECOS"`.
 If no solver is specified, `diffcp` will choose the solver itself.
 In the case that the problem is not solved, i.e. the solver fails for some reason, we will raise

--- a/diffcp/__init__.py
+++ b/diffcp/__init__.py
@@ -1,7 +1,7 @@
 __version__ = "1.0.13"
 
 from diffcp.cone_program import solve_and_derivative, \
-                                solve_and_derivative_batch, \
-                                solve_and_derivative_internal, SolverError
+    solve_and_derivative_batch, \
+    solve_and_derivative_internal, SolverError
 from diffcp.cones import ZERO, POS, SOC, PSD, EXP
 from diffcp import utils

--- a/diffcp/__init__.py
+++ b/diffcp/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.0.13"
+__version__ = "1.0.15"
 
 from diffcp.cone_program import solve_and_derivative, \
     solve_and_derivative_batch, \

--- a/examples/batch_ecos.py
+++ b/examples/batch_ecos.py
@@ -1,0 +1,44 @@
+import diffcp
+import utils
+import IPython as ipy
+import time
+import numpy as np
+
+m = 100
+n = 50
+
+batch_size = 16
+n_jobs = 1
+
+As, bs, cs, Ks = [], [], [], []
+for _ in range(batch_size):
+    A, b, c, K = diffcp.utils.least_squares_eq_scs_data(m, n)
+    As += [A]
+    bs += [b]
+    cs += [c]
+    Ks += [K]
+
+
+def time_function(f, N=1):
+    result = []
+    for i in range(N):
+        tic = time.time()
+        f()
+        toc = time.time()
+        result += [toc - tic]
+    return np.mean(result), np.std(result)
+
+for n_jobs in range(1, 5):
+    def f_forward():
+        return diffcp.solve_and_derivative_batch(As, bs, cs, Ks,
+                                                 n_jobs_forward=n_jobs, n_jobs_backward=n_jobs, solver="ECOS", verbose=False)
+    xs, ys, ss, D_batch, DT_batch = diffcp.solve_and_derivative_batch(As, bs, cs, Ks,
+                                                                      n_jobs_forward=1, n_jobs_backward=n_jobs, solver="ECOS", verbose=False)
+
+    def f_backward():
+        DT_batch(xs, ys, ss, mode="lsqr")
+
+    mean_forward, std_forward = time_function(f_forward)
+    mean_backward, std_backward = time_function(f_backward)
+    print("%03d | %4.4f +/- %2.2f | %4.4f +/- %2.2f" %
+          (n_jobs, mean_forward, std_forward, mean_backward, std_backward))

--- a/examples/batch_ecos.py
+++ b/examples/batch_ecos.py
@@ -28,7 +28,7 @@ def time_function(f, N=1):
         result += [toc - tic]
     return np.mean(result), np.std(result)
 
-for n_jobs in range(1, 5):
+for n_jobs in range(1, 8):
     def f_forward():
         return diffcp.solve_and_derivative_batch(As, bs, cs, Ks,
                                                  n_jobs_forward=n_jobs, n_jobs_backward=n_jobs, solver="ECOS", verbose=False)

--- a/examples/ecos_example.py
+++ b/examples/ecos_example.py
@@ -1,0 +1,40 @@
+import diffcp
+
+import numpy as np
+import utils
+np.set_printoptions(precision=5, suppress=True)
+
+
+# We generate a random cone program with a cone
+# defined as a product of a 3-d fixed cone, 3-d positive orthant cone,
+# and a 5-d second order cone.
+K = {
+    'f': 3,
+    'l': 3,
+    'q': [5]
+}
+
+m = 3 + 3 + 5
+n = 5
+
+np.random.seed(0)
+
+A, b, c = utils.random_cone_prog(m, n, K)
+
+# We solve the cone program and get the derivative and its adjoint
+x, y, s, derivative, adjoint_derivative = diffcp.solve_and_derivative(
+    A, b, c, K, solver="ECOS", verbose=False)
+
+print("x =", x)
+print("y =", y)
+print("s =", s)
+
+# We evaluate the gradient of the objective with respect to A, b and c.
+dA, db, dc = adjoint_derivative(c, np.zeros(
+    m), np.zeros(m), atol=1e-10, btol=1e-10)
+
+# The gradient of the objective with respect to b should be
+# equal to minus the dual variable y (see, e.g., page 268 of Convex Optimization by
+# Boyd & Vandenberghe).
+print("db =", db)
+print("-y =", -y)

--- a/setup.py
+++ b/setup.py
@@ -55,18 +55,19 @@ def march_native():
 
 
 _diffcp = Extension(
-        '_diffcp',
-        glob("cpp/src/*.cpp"),
-        include_dirs=[
-            get_pybind_include(),
-            get_pybind_include(user=True),
-            "cpp/external/eigen",
-            "cpp/external/eigen/Eigen",
-            "cpp/include",
-        ],
-        language='c++',
-        extra_compile_args=["-O3", "-std=c++11"] + openmp() + march_native()
+    '_diffcp',
+    glob("cpp/src/*.cpp"),
+    include_dirs=[
+        get_pybind_include(),
+        get_pybind_include(user=True),
+        "cpp/external/eigen",
+        "cpp/external/eigen/Eigen",
+        "cpp/include",
+    ],
+    language='c++',
+    extra_compile_args=["-O3", "-std=c++11"] + openmp() + march_native()
 )
+
 
 def is_platform_mac():
     return sys.platform == 'darwin'
@@ -89,7 +90,7 @@ ext_modules = [_diffcp]
 
 setup(
     name='diffcp',
-    version="1.0.13",
+    version="1.0.15",
     author="Akshay Agrawal, Shane Barratt, Stephen Boyd, Enzo Busseti, Walaa Moursi",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -100,7 +100,8 @@ setup(
         "scs >= 2.0.2",  # 2.0.2 is the oldest version on conda forge
         "scipy >= 1.1.0",
         "pybind11 >= 2.4",
-        "threadpoolctl >= 1.1"],
+        "threadpoolctl >= 1.1",
+        "ecos"],
     url="http://github.com/cvxgrp/diffcp/",
     ext_modules=ext_modules,
     license="Apache License, Version 2.0",


### PR DESCRIPTION
This PR adds ECOS as an optional solver for diffcp, and chooses ECOS over SCS when there are no PSD/exponential cones. All that changes is the solver used; it still uses the SCS canonical form. It would be nice to add a parallelizable version of ECOS (see, e.g., https://github.com/embotech/ecos-python/pull/20) as a submodule before it's fully in ECOS. I also added some tests

TODO eventually: support exponential cone, which requires some re-ordering for ECOS.