### PR TITLE
Drop projections to C++ and add cone program refinement

### DIFF
--- a/cpp/include/cones.h
+++ b/cpp/include/cones.h
@@ -16,6 +16,20 @@ public:
       : type(type), sizes(sizes){};
 };
 
+/* Project `x` onto the primal or dual cone.
+ *
+ *  Args:
+ *    x:     The point at which to evaluate the derivative
+ *    cones: A list of cones; the cone on which to project is the cartesian
+ *           product of these cones
+ *    dual:  whether to project onto the dual cone
+ *
+ *  Returns:
+ *    A Vector with the projection.
+ */
+Vector projection(const Vector &x, const std::vector<Cone> &cones,
+                  bool dual);
+
 /* Compute the derivative, at `x`, of a projection onto a cone.
  *
  *  Args:

--- a/cpp/include/deriv.h
+++ b/cpp/include/deriv.h
@@ -3,12 +3,24 @@
 #include "cones.h"
 #include "eigen_includes.h"
 #include "linop.h"
+#include "lsqr.h"
+
+LinearOperator dpi(const Vector &u, const Vector &v, double w,
+                   const std::vector<Cone> &cones);
+
+Matrix dpi_dense(const Vector &u, const Vector &v, double w,
+                 const std::vector<Cone> &cones);
 
 LinearOperator M_operator(const SparseMatrix &Q, const std::vector<Cone> &cones,
                           const Vector &u, const Vector &v, double w);
 
 Matrix M_dense(const Matrix &Q, const std::vector<Cone> &cones, const Vector &u,
                const Vector &v, double w);
+
+LsqrResult _solve_adjoint_derivative_lsqr(
+    const SparseMatrix &Q, const std::vector<Cone> &cones,
+    const Vector &u, const Vector &v, double w, const Vector &dz);
+
 
 // this function releases the GIL.
 Vector _solve_derivative_dense(const Matrix &M, const Matrix &MT,

--- a/cpp/include/eigen_includes.h
+++ b/cpp/include/eigen_includes.h
@@ -4,6 +4,7 @@
 #include "Eigen/Sparse"
 
 using Vector = Eigen::VectorXd;
+using VectorRef = Eigen::Ref<Eigen::VectorXd>;
 using Array = Eigen::Array<double, Eigen::Dynamic, 1>;
 using Matrix = Eigen::MatrixXd;
 using MatrixRef = Eigen::Ref<Eigen::MatrixXd>;

--- a/cpp/include/residual.h
+++ b/cpp/include/residual.h
@@ -1,0 +1,81 @@
+#pragma once
+
+#include "cones.h"
+#include "eigen_includes.h"
+#include "linop.h"
+#include "lsqr.h"
+#include "deriv.h"
+
+std::tuple<Vector, Vector> proj_pq(const std::vector<Cone> &cones,
+                                   const Vector &u, const Vector &v, double w);
+
+/**
+ * Refines the solution to a cone program by using LSQR to improve
+ * the normalized residual map:
+ * https://stanford.edu/~boyd/papers/pdf/cone_prog_refine.pdf
+ */
+Vector refine(const SparseMatrix &Q, const std::vector<Cone> &cones,
+              const Vector &u, const Vector &v, double w,
+              const int n_iter,
+              const double lsqr_lambda=1e-8,
+              const double lsqr_iter_lim=30,
+              const int alpha_K=10);
+
+
+/**
+ * Compute the value of the residual map at a point z = (u, v, w)
+ * for a cone program defined by a sparse Q.
+ */
+Vector residual(const SparseMatrix &Q, const std::vector<Cone> &cones,
+                const Vector &u, const Vector &v, double w);
+
+/**
+ * Compute the value of the normalized residual map at a point z = (u, v, w)
+ * for a cone program defined by a sparse Q.
+ */
+Vector N_residual(const SparseMatrix &Q, const std::vector<Cone> &cones,
+                  const Vector &u, const Vector &v, double w);
+
+/**
+ * Compute the value of the residual map at a point z = (u, v, w)
+ * for a cone program defined by a dense Q.
+ */
+Vector residual_dense(const Matrix &Q, const std::vector<Cone> &cones,
+                      const Vector &u, const Vector &v, double w);
+
+/**
+ * Compute the value of the normalized residual map at a point z = (u, v, w)
+ * for a cone program defined by a sparse Q.
+ */
+Vector N_residual_dense(const Matrix &Q, const std::vector<Cone> &cones,
+                        const Vector &u, const Vector &v, double w);
+
+/**
+ * The derivative of the normalized residual map at a point z = (u, v, w)
+ * for a cone program defined by a sparse Q.
+ */
+LinearOperator DN(const SparseMatrix &Q, const std::vector<Cone> &cones,
+                  const Vector &u, const Vector &v, double w);
+
+/**
+ * The derivative of the normalized residual map at a point z = (u, v, w)
+ * for a cone program defined by a dense Q.
+ */
+Matrix DN_dense(const Matrix &Q, const std::vector<Cone> &cones, const Vector &u,
+                const Vector &v, double w);
+
+/**
+ * Left-multiply a point dz = (du, dv, dw) by the derivative of the
+ * normalized residual map.
+ */
+Vector apply_DN_matvec(const SparseMatrix &Q, const std::vector<Cone> &cones,
+                       const Vector &u, const Vector &v, double w,
+                       const Vector &du, const Vector &dv, double dw);
+
+/**
+ * Right-multiply a point dz = (du, dv, dw) by the derivative of the
+ * normalized residual map.
+ */
+Vector apply_DN_rmatvec(const SparseMatrix &Q, const std::vector<Cone> &cones,
+                        const Vector &u, const Vector &v, double w,
+                        const Vector &du, const Vector &dv, double dw);

--- a/cpp/src/deriv.cpp
+++ b/cpp/src/deriv.cpp
@@ -50,10 +50,20 @@ Matrix M_dense(const Matrix &Q, const std::vector<Cone> &cones, const Vector &u,
   return (Q - eye) * dpi_dense(u, v, w, cones) + eye;
 }
 
+
 Vector _solve_derivative_dense(const Matrix &M, const Matrix &MT,
                                const Vector &rhs) {
   // TODO: Factorization could be cached to optimize multiple calls
   return (MT * M).ldlt().solve(MT * rhs);
+}
+
+LsqrResult _solve_adjoint_derivative_lsqr(
+    const SparseMatrix &Q, const std::vector<Cone> &cones,
+    const Vector &u, const Vector &v, double w, const Vector &dz) {
+  LinearOperator M = M_operator(Q, cones, u, v, w);
+  LinearOperator MT = M.transpose();
+  LsqrResult result = lsqr(MT, dz);
+  return result;
 }
 
 Vector _solve_adjoint_derivative_dense(const Matrix &M, const Matrix &MT,

--- a/cpp/src/residual.cpp
+++ b/cpp/src/residual.cpp
@@ -1,0 +1,170 @@
+#include "residual.h"
+#include "lsqr.h"
+#include "deriv.h"
+#include <tuple>
+#include <iostream>
+
+inline double gt(double x, double t) {
+  if (x >= t) {
+    return 1.0;
+  } else {
+    return 0.0;
+  }
+}
+
+std::tuple<Vector, Vector> proj_pq(const std::vector<Cone> &cones,
+          const Vector &u, const Vector &v, double w) {
+  int n = u.size();
+  int m = v.size();
+  int N = n + m + 1;
+  Vector z = Vector::Zero(N);
+  z << u, v, w;
+  Vector p = Vector(N);
+  p << u, projection(v, cones, true), std::max(w, 0.0);
+  Vector q = p - z;
+  return {p, q};
+}
+
+Vector residual(const SparseMatrix &Q, const std::vector<Cone> &cones,
+                const Vector &u, const Vector &v, double w) {
+  auto [p, q] = proj_pq(cones, u, v, w);
+  return Q*p - q;
+}
+
+Vector N_residual(const SparseMatrix &Q, const std::vector<Cone> &cones,
+                  const Vector &u, const Vector &v, double w) {
+  return residual(Q, cones, u, v, w) / w;
+}
+
+Vector residual_dense(const Matrix &Q, const std::vector<Cone> &cones,
+                      const Vector &u, const Vector &v, double w) {
+  auto [p, q] = proj_pq(cones, u, v, w);
+  return Q*p - q;
+}
+
+Vector N_residual_dense(const Matrix &Q, const std::vector<Cone> &cones,
+                        const Vector &u, const Vector &v, double w) {
+  return residual_dense(Q, cones, u, v, w) / w;
+}
+
+
+Vector apply_DN_matvec(const SparseMatrix &Q, const std::vector<Cone> &cones,
+                       const Vector &u, const Vector &v, double w,
+                       const Vector &du, const Vector &dv, double dw) {
+  int N = u.size() + v.size() + 1;
+  LinearOperator dpi_op = dpi(u, v, w, cones);
+
+  Vector dz = Vector::Zero(N);
+  dz << du, dv, dw;
+
+  Vector dpi_mv = dpi_op.matvec(dz);
+  Vector result = (Q*dpi_mv - dpi_mv + dz) / abs(w);
+  float dz_w = dz[N-1];
+  Vector last_row_offset = gt(w, 0.0) * residual(Q, cones, u, v, w) / (w*w);
+  result -= dz_w * last_row_offset;
+  return result;
+}
+
+Vector apply_DN_rmatvec(const SparseMatrix &Q, const std::vector<Cone> &cones,
+                        const Vector &u, const Vector &v, double w,
+                        const Vector &du, const Vector &dv, double dw) {
+  int N = u.size() + v.size() + 1;
+  LinearOperator dpi_op = dpi(u, v, w, cones);
+
+  Vector dz = Vector::Zero(N);
+  dz << du, dv, dw;
+
+  Vector t = Q.transpose() * dz - dz;
+  Vector dpi_t_rmv = dpi_op.rmatvec(t);
+  Vector result = (dpi_t_rmv + dz) / abs(w);
+  Vector last_row_offset = gt(w, 0.0) * residual(Q, cones, u, v, w) / (w*w);
+  result[N-1] -= last_row_offset.dot(dz);
+  return result;
+}
+
+
+LinearOperator DN(const SparseMatrix &Q, const std::vector<Cone> &cones,
+                  const Vector &u, const Vector &v, double w) {
+  int N = u.size() + v.size() + 1;
+  LinearOperator dpi_op = dpi(u, v, w, cones);
+
+  // TODO: Potentially remove duplicated code applying the matvec/rmatvec,
+  // but keeping for now to cache dpi_op.
+  const VecFn matvec = [Q,cones,u,v,w,N,dpi_op](const Vector &dz) -> Vector {
+    Vector dpi_mv = dpi_op.matvec(dz);
+    Vector result = (Q*dpi_mv - dpi_mv + dz) / abs(w);
+    float dz_w = dz[N-1];
+    Vector last_row_offset = gt(w, 0.0) * residual(Q, cones, u, v, w) / (w*w);
+    result -= dz_w * last_row_offset;
+    return result;
+  };
+  const VecFn rmatvec = [Q,cones,u,v,w,N,dpi_op](const Vector &dz) -> Vector {
+    Vector t = Q.transpose() * dz - dz;
+    Vector dpi_t_rmv = dpi_op.rmatvec(t);
+    Vector result = (dpi_t_rmv + dz) / abs(w);
+    Vector last_row_offset = gt(w, 0.0) * residual(Q, cones, u, v, w) / (w*w);
+    result[N-1] -= last_row_offset.dot(dz);
+    return result;
+  };
+  return LinearOperator(N, N, matvec, rmatvec);
+}
+
+Matrix DN_dense(const Matrix &Q, const std::vector<Cone> &cones,
+                const Vector &u, const Vector &v, double w) {
+  int n = u.size();
+  int m = v.size();
+  int N = n + m + 1;
+  Matrix eye = Matrix::Identity(N, N);
+  Matrix DN = (Q - eye) * dpi_dense(u, v, w, cones) + eye;
+  DN /= abs(w);
+
+  Vector last_row_offset = gt(w, 0.0) * residual_dense(Q, cones, u, v, w) / (w*w);
+  DN.col(N-1) -= last_row_offset;
+  return DN;
+}
+
+Vector refine(const SparseMatrix &Q, const std::vector<Cone> &cones,
+              const Vector &in_u, const Vector &in_v, double in_w,
+              const int n_iter,
+              const double lambda,
+              const double lsqr_iter_lim,
+              const int alpha_K) {
+  int n = in_u.size();
+  int m = in_v.size();
+  int N = n + m + 1;
+
+  Vector z = Vector(N);
+  z << in_u, in_v, in_w;
+
+  for (int i = 0; i < n_iter; ++i) {
+    Vector z_u = z.segment(0, n);
+    Vector z_v = z.segment(n, m);
+    double z_w = z[N-1];
+    Vector res = N_residual(Q, cones, z_u, z_v, z_w);
+    double res_norm = res.norm();
+
+    LinearOperator DN_op = DN(Q, cones, z_u, z_v, z_w);
+    double lsqr_atol = 1e-8;
+    double lsqr_btol = 1e-8;
+    LsqrResult result = lsqr(DN_op, res, lambda, lsqr_atol, lsqr_btol,
+                             1e8, lsqr_iter_lim);
+    Vector step = result.x;
+
+    int alpha_k = 0;
+    double next_norm = res_norm + 1.;
+    Vector next_z;
+    while ((next_norm > res_norm) & (alpha_k < alpha_K)) {
+      double alpha = 1./((double) (2 << alpha_k));
+      next_z = z - alpha * step;
+      Vector next_z_u = next_z.segment(0, n);
+      Vector next_z_v = next_z.segment(n, m);
+      double next_z_w = next_z[N-1];
+      Vector next_res = N_residual(Q, cones, next_z_u, next_z_v, next_z_w);
+      next_norm = next_res.norm();
+      alpha_k += 1;
+    }
+    z << next_z;
+  }
+
+  return z;
+}

--- a/cpp/src/wrapper.cpp
+++ b/cpp/src/wrapper.cpp
@@ -6,6 +6,7 @@
 #include "deriv.h"
 #include "linop.h"
 #include "lsqr.h"
+#include "residual.h"
 
 namespace py = pybind11;
 
@@ -46,10 +47,26 @@ PYBIND11_MODULE(_diffcp, m) {
   m.def("M_dense", &M_dense, py::call_guard<py::gil_scoped_release>());
   m.def("_solve_derivative_dense", &_solve_derivative_dense, py::call_guard<py::gil_scoped_release>());
   m.def("_solve_adjoint_derivative_dense", &_solve_adjoint_derivative_dense, py::call_guard<py::gil_scoped_release>());
+  m.def("_solve_adjoint_derivative_lsqr", &_solve_adjoint_derivative_lsqr, py::call_guard<py::gil_scoped_release>());
 
-  m.def("dprojection", &dprojection);
-  m.def("dprojection_dense", &dprojection_dense);
+  m.def("projection", &projection, py::call_guard<py::gil_scoped_release>());
+  m.def("dprojection", &dprojection, py::call_guard<py::gil_scoped_release>());
+  m.def("dprojection_dense", &dprojection_dense, py::call_guard<py::gil_scoped_release>());
+  m.def("dpi", &dpi, py::call_guard<py::gil_scoped_release>());
+  m.def("dpi_dense", &dpi_dense, py::call_guard<py::gil_scoped_release>());
   m.def("project_exp_cone", &project_exp_cone);
   m.def("in_exp", &in_exp);
   m.def("in_exp_dual", &in_exp_dual);
+
+  // residual.h
+  m.def("proj_pq", &proj_pq, py::call_guard<py::gil_scoped_release>());
+  m.def("residual", &residual, py::call_guard<py::gil_scoped_release>());
+  m.def("N_residual", &N_residual, py::call_guard<py::gil_scoped_release>());
+  m.def("residual_dense", &residual_dense, py::call_guard<py::gil_scoped_release>());
+  m.def("N_residual_dense", &N_residual_dense, py::call_guard<py::gil_scoped_release>());
+  m.def("DN", &DN, py::call_guard<py::gil_scoped_release>());
+  m.def("apply_DN_matvec", &apply_DN_matvec, py::call_guard<py::gil_scoped_release>());
+  m.def("apply_DN_rmatvec", &apply_DN_rmatvec, py::call_guard<py::gil_scoped_release>());
+  m.def("DN_dense", &DN_dense, py::call_guard<py::gil_scoped_release>());
+  m.def("refine", &refine, py::call_guard<py::gil_scoped_release>());
 }

--- a/diffcp/cones.py
+++ b/diffcp/cones.py
@@ -3,7 +3,7 @@ import scipy.sparse as sparse
 import scipy.sparse.linalg as splinalg
 import warnings
 
-from _diffcp import dprojection, project_exp_cone, Cone, ConeType
+from _diffcp import projection, dprojection, project_exp_cone, Cone, ConeType
 
 ZERO = "f"
 POS = "l"
@@ -118,7 +118,7 @@ def _proj(x, cone, dual=False):
         raise NotImplementedError("%s not implemented" % cone)
 
 
-def pi(x, cones, dual=False):
+def pi_python(x, cones, dual=False):
     """Projects x onto product of cones (or their duals)
     Args:
         x: NumPy array (with PSD data formatted in SCS convention)
@@ -142,3 +142,16 @@ def pi(x, cones, dual=False):
                 x[offset:offset + dim], cone, dual=dual)
             offset += dim
     return projection
+
+def pi(x, cones, dual=False):
+    """Projects x onto product of cones (or their duals)
+    Args:
+        x: NumPy array (with PSD data formatted in SCS convention)
+        cones: list of (cone name, size)
+        dual: whether to project onto the dual cone
+    Returns:
+        NumPy array that is the projection of `x` onto the (dual) cones
+    """
+
+    cone_list_cpp = parse_cone_dict_cpp(cones)
+    return projection(x, cone_list_cpp, dual)

--- a/prof.py
+++ b/prof.py
@@ -8,25 +8,27 @@ import diffcp.cone_program as cone_prog
 import diffcp.cones as cone_lib
 import diffcp.utils as utils
 
-
 modes = ['lsqr']
 # modes = ['lsqr', 'dense']
 n_batch = 256
 m = 100
 n = 50
 n_trial = 10
+eps = 1e-4
 
 data = []
 for i in range(n_batch):
     data.append(utils.least_squares_eq_scs_data(m, n, seed=i))
 A, b, c, cone_dims = zip(*data)
 
+print('mode forward_time adjoint_time adjoint_derivative_time')
+
 for mode in modes:
     forward_time = 0.0
     for i in range(n_trial):
         tic = time.time()
         x, y, s, derivative, adjoint_derivative = cone_prog.solve_and_derivative_batch(
-            A, b, c, cone_dims, eps=1e-10, mode=mode)
+            A, b, c, cone_dims, eps=eps, mode=mode)
         toc = time.time()
         forward_time += (toc - tic) / float(n_trial)
 


### PR DESCRIPTION
Hi, here's the initial version of dropping the projections to C++ and adding the refinement from [this paper](https://stanford.edu/~boyd/papers/pdf/cone_prog_refine.pdf). What do you all think?

+ I replaced `pi` to call into C++ and moved the old Python version to `pi_python`
+ Everything in `tests.py` works with the C++ projections
+ I tested the refinement code by comparing the iterates to the numba version [here](https://github.com/cvxgrp/cone_prog_refine). They consistently match and this is consistently able to improve the results. I don't currently have any examples/tests in here but can add one. The runtime with eigen can be somewhat slow compared to the SCS call but long-term maybe this could be optimized
+ I moved the pre-computations into the `derivative` and `adjoint_derivative` functions to better-compare the runtimes here. Something else I noticed is that we can improve the runtime a bit by not returning `M` back up to Python, so I created `_solve_adjoint_derivative_lsqr`. We can also do the same thing for the derivative, or can revert this if you all want to keep the pre-computations in `solve`
+ Running `prof.py` from this PR on the old code and here shows this PR doesn't slow down anything on this example and gives a slight performance boost on the adjoint derivative from `solve_adjoint_derivative_lsqr`. In the "old code" I also moved the pre-computations into the `derivative` and `adjoint_derivative` for a fair comparison here

```
forward_time adjoint_time adjoint_derivative_time
Old code: 0.1274257183074951 2.0571622371673586 1.5252753496170044
This PR: 0.1262342929840088 2.0498327732086183 1.100463008880615
```