### PR TITLE
Initial C++ projection

### DIFF
--- a/cpp/include/cones.h
+++ b/cpp/include/cones.h
@@ -16,6 +16,20 @@ public:
       : type(type), sizes(sizes){};
 };
 
+/* Project `x` onto the primal or dual cone.
+ *
+ *  Args:
+ *    x:     The point at which to evaluate the derivative
+ *    cones: A list of cones; the cone on which to project is the cartesian
+ *           product of these cones
+ *    dual:  whether to project onto the dual cone
+ *
+ *  Returns:
+ *    A Vector with the projection.
+ */
+Vector projection(const Vector &x, const std::vector<Cone> &cones,
+                  bool dual);
+
 /* Compute the derivative, at `x`, of a projection onto a cone.
  *
  *  Args:

--- a/cpp/include/deriv.h
+++ b/cpp/include/deriv.h
@@ -4,6 +4,12 @@
 #include "eigen_includes.h"
 #include "linop.h"
 
+LinearOperator dpi(const Vector &u, const Vector &v, double w,
+                   const std::vector<Cone> &cones);
+
+Matrix dpi_dense(const Vector &u, const Vector &v, double w,
+                 const std::vector<Cone> &cones);
+
 LinearOperator M_operator(const SparseMatrix &Q, const std::vector<Cone> &cones,
                           const Vector &u, const Vector &v, double w);
 

--- a/cpp/include/eigen_includes.h
+++ b/cpp/include/eigen_includes.h
@@ -4,6 +4,7 @@
 #include "Eigen/Sparse"
 
 using Vector = Eigen::VectorXd;
+using VectorRef = Eigen::Ref<Eigen::VectorXd>;
 using Array = Eigen::Array<double, Eigen::Dynamic, 1>;
 using Matrix = Eigen::MatrixXd;
 using MatrixRef = Eigen::Ref<Eigen::MatrixXd>;

--- a/cpp/src/wrapper.cpp
+++ b/cpp/src/wrapper.cpp
@@ -47,8 +47,11 @@ PYBIND11_MODULE(_diffcp, m) {
   m.def("_solve_derivative_dense", &_solve_derivative_dense, py::call_guard<py::gil_scoped_release>());
   m.def("_solve_adjoint_derivative_dense", &_solve_adjoint_derivative_dense, py::call_guard<py::gil_scoped_release>());
 
-  m.def("dprojection", &dprojection);
-  m.def("dprojection_dense", &dprojection_dense);
+  m.def("projection", &projection, py::call_guard<py::gil_scoped_release>());
+  m.def("dprojection", &dprojection, py::call_guard<py::gil_scoped_release>());
+  m.def("dprojection_dense", &dprojection_dense, py::call_guard<py::gil_scoped_release>());
+  m.def("dpi", &dpi, py::call_guard<py::gil_scoped_release>());
+  m.def("dpi_dense", &dpi_dense, py::call_guard<py::gil_scoped_release>());
   m.def("project_exp_cone", &project_exp_cone);
   m.def("in_exp", &in_exp);
   m.def("in_exp_dual", &in_exp_dual);

--- a/diffcp/cones.py
+++ b/diffcp/cones.py
@@ -3,7 +3,7 @@ import scipy.sparse as sparse
 import scipy.sparse.linalg as splinalg
 import warnings
 
-from _diffcp import dprojection, project_exp_cone, Cone, ConeType
+from _diffcp import projection, dprojection, project_exp_cone, Cone, ConeType
 
 ZERO = "f"
 POS = "l"
@@ -127,18 +127,6 @@ def pi(x, cones, dual=False):
     Returns:
         NumPy array that is the projection of `x` onto the (dual) cones
     """
-    projection = np.zeros(x.shape)
-    offset = 0
-    for cone, sz in cones:
-        sz = sz if isinstance(sz, (tuple, list)) else (sz,)
-        if sum(sz) == 0:
-            continue
-        for dim in sz:
-            if cone == PSD:
-                dim = vec_psd_dim(dim)
-            elif cone == EXP or cone == EXP_DUAL:
-                dim *= 3
-            projection[offset:offset + dim] = _proj(
-                x[offset:offset + dim], cone, dual=dual)
-            offset += dim
-    return projection
+
+    cone_list_cpp = parse_cone_dict_cpp(cones)
+    return projection(x, cone_list_cpp, dual)


### PR DESCRIPTION
Smaller PR of just this from #39. Will send in the refinement PR on top of this once it's merged

I've replaced `pi` with the C++ version, but the tests are currently calling into the Python code for the individual projections and then calling into C++ for the overall test of `pi`. If it sounds good to you all I can remove the Python projection code and then make the individual projection tests check the C++ code. 