### PR TITLE
Make ECOS interface compatible with CVXPY DIFFCP

### DIFF
--- a/diffcp/cone_program.py
+++ b/diffcp/cone_program.py
@@ -348,6 +348,19 @@ def solve_and_derivative_internal(A, b, c, cone_dict, solve_method=None,
         if status not in [0, 10]:
             raise SolverError("Solver ecos returned status %s" %
                               STATUS_LOOKUP[status])
+
+        # Convert ECOS info into SCS info to be compatible if called from
+        # CVXPY DIFFCP solver
+        ECOS2SCS_STATUS_MAP = {0: "Solved", 1: "Infeasible", 2: "Unbounded",
+                               10: "Solved/Inaccurate",
+                               11: "Infeasible/Inaccurate",
+                               12: "Unbounded/Inaccurate"}
+        result['info'] = {'status': ECOS2SCS_STATUS_MAP.get(status, "Failure"),
+                          'solveTime': solution['info']['timing']['tsolve'],
+                          'setupTime': solution['info']['timing']['tsetup'],
+                          'iter': solution['info']['iter'],
+                          'pobj': solution['info']['pcost']}
+
     else:
         raise ValueError("Solver %s not supported." % solve_method)
 


### PR DESCRIPTION
This minor edit creates an `info` dictionary inside `result` to make ECOS compatible with SCS format. This is useful when ECOS is called within CVXPY DIFFCP.

This is used in https://github.com/cvxgrp/cvxpy/pull/1291