### PR TITLE
SCS 3.0 (Issue 47)

### DIFF
--- a/diffcp/cone_program.py
+++ b/diffcp/cone_program.py
@@ -1,18 +1,16 @@
-import warnings
-
-import diffcp.cones as cone_lib
-
-import numpy as np
-import scipy.sparse as sparse
-import scipy.sparse.linalg as splinalg
-import scs
-import ecos
-from threadpoolctl import threadpool_limits
-
 import multiprocessing as mp
+import warnings
 from multiprocessing.pool import ThreadPool
 
+import ecos
+import numpy as np
+import scipy.sparse as sparse
+import scs
+from distutils.version import StrictVersion
+from threadpoolctl import threadpool_limits
+
 import _diffcp
+import diffcp.cones as cone_lib
 
 
 def pi(z, cones):
@@ -257,6 +255,21 @@ def solve_and_derivative_internal(A, b, c, cone_dict, solve_method=None,
             solve_method = "ECOS"
 
     if solve_method == "SCS":
+
+        # SCS versions SCS 2.*
+        if StrictVersion(scs.__version__) < StrictVersion('3.0.0'):
+            if "eps_abs" in kwargs or "eps_rel" in kwargs:
+                # Take the min of eps_rel and eps_abs to be eps
+                kwargs["eps"] = min(kwargs.get("eps_abs", 1),
+                                    kwargs.get("eps_rel", 1))
+
+        # SCS version 3.*
+        else:
+            if "eps" in kwargs:  # eps replaced by eps_abs, eps_rel
+                kwargs["eps_abs"] = kwargs["eps"]
+                kwargs["eps_rel"] = kwargs["eps"]
+                del kwargs["eps"]
+
         data = {
             "A": A,
             "b": b,
@@ -272,15 +285,16 @@ def solve_and_derivative_internal(A, b, c, cone_dict, solve_method=None,
         result = scs.solve(data, cone_dict, **kwargs)
 
         status = result["info"]["status"]
-        if status == "Solved/Inaccurate" and "acceleration_lookback" not in kwargs:
+        inaccurate_status = {"Solved/Inaccurate", "solved (inaccurate - reached max_iters)"}
+        if status in inaccurate_status and "acceleration_lookback" not in kwargs:
             # anderson acceleration is sometimes unstable
             result = scs.solve(
                 data, cone_dict, acceleration_lookback=0, **kwargs)
             status = result["info"]["status"]
 
-        if status == "Solved/Inaccurate":
+        if status in inaccurate_status:
             warnings.warn("Solved/Inaccurate.")
-        elif status != "Solved":
+        elif status.lower() != "solved":
             if raise_on_error:
                 raise SolverError("Solver scs returned status %s" % status)
             else:
@@ -302,7 +316,7 @@ def solve_and_derivative_internal(A, b, c, cone_dict, solve_method=None,
             raise NotImplementedError("Exponential cones not supported yet.")
         if warm_start is not None:
             raise ValueError("ECOS does not support warm starting.")
-        len_eq = cone_dict["f"]
+        len_eq = cone_dict[cone_lib.EQ_DIM]
         C_ecos = c
         G_ecos = A[len_eq:]
         if 0 in G_ecos.shape:

--- a/diffcp/cones.py
+++ b/diffcp/cones.py
@@ -1,11 +1,15 @@
 import numpy as np
 import scipy.sparse as sparse
-import scipy.sparse.linalg as splinalg
-import warnings
+from _diffcp import project_exp_cone, Cone, ConeType
+from distutils.version import StrictVersion
+import scs
 
-from _diffcp import dprojection, project_exp_cone, Cone, ConeType
+if StrictVersion(scs.__version__) >= StrictVersion('3.0.0'):
+    EQ_DIM = "z"
+else:
+    EQ_DIM = "f"
 
-ZERO = "f"
+ZERO = EQ_DIM
 POS = "l"
 SOC = "q"
 PSD = "s"
@@ -17,7 +21,7 @@ CONES = [ZERO, POS, SOC, PSD, EXP, EXP_DUAL]
 
 # Map from Python cones to CPP format
 CONE_MAP = {
-    "f": ConeType.ZERO,
+    EQ_DIM: ConeType.ZERO,
     "l": ConeType.POS,
     "q": ConeType.SOC,
     "s": ConeType.PSD,

--- a/tests/test_cone_prog_diff.py
+++ b/tests/test_cone_prog_diff.py
@@ -10,7 +10,7 @@ import diffcp.cones as cone_lib
 import diffcp.utils as utils
 
 CPP_CONES_TO_SCS = {
-    ConeType.ZERO: "f",
+    ConeType.ZERO: cone_lib.EQ_DIM,
     ConeType.POS: "l",
     ConeType.SOC: "q",
     ConeType.PSD: "s",

--- a/tests/test_ecos.py
+++ b/tests/test_ecos.py
@@ -51,6 +51,6 @@ def test_infeasible():
     c = np.ones(1)
     b = np.array([1.0, -1.0])
     A = sparse.csc_matrix(np.ones((2, 1)))
-    cone_dims = {"f": 2}
+    cone_dims = {cone_lib.EQ_DIM: 2}
     with pytest.raises(cone_prog.SolverError, match=r"Solver ecos returned status Infeasible"):
         cone_prog.solve_and_derivative(A, b, c, cone_dims, solve_method="ECOS")

--- a/tests/test_scs.py
+++ b/tests/test_scs.py
@@ -50,9 +50,9 @@ def test_warm_start():
     n = 10
     A, b, c, cone_dims = utils.least_squares_eq_scs_data(m, n)
     x, y, s, _, _ = cone_prog.solve_and_derivative(
-        A, b, c, cone_dims, eps=1e-11, solve_method="SCS")
+        A, b, c, cone_dims, eps=1e-9, solve_method="SCS")
     x_p, y_p, s_p, _, _ = cone_prog.solve_and_derivative(
-        A, b, c, cone_dims, warm_start=(x, y, s), max_iters=1, solve_method="SCS")
+        A, b, c, cone_dims, warm_start=(x, y, s), max_iters=1, solve_method="SCS", eps=1e-9)
 
     np.testing.assert_allclose(x, x_p, atol=1e-7)
     np.testing.assert_allclose(y, y_p, atol=1e-7)


### PR DESCRIPTION
Some remarks:
- ~Using `cvxpy/master`, `diffcp/master`, and `SCS 2.1.4`, `test_derivative.py` takes about 1 min~
- ~Using `cvxpy/phschiele:SCS.3.0.0-patch`, `diffcp/phschiele:SCS-3.0.0`, and `SCS 3.0,0`, `test_derivative.py` takes about 20 min, with three tests failing due to accuracy.~
~-> Currently trying to pin down where this is coming from~
Edit: This has been resolved by reducing `eps` from ` 1e-10` to `1e-9` in `gradcheck()` and `perturbcheck()`.

- It's not ideal that the internal handling of ECOS constraints also is influenced by which version of SCS is installed. Since they share much of the code, it was not easily possible to separate the keys used. Happy to hear other suggestions here.

