### PR TITLE
Fix source deploy

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Set Additional Envs
         run: |
           echo "PYTHON_SUBVERSION=$(echo $PYTHON_VERSION | cut -c 3-)" >> $GITHUB_ENV
-          echo "DEPLOY_PYPI_SOURCE=$( [[ $PYTHON_VERSION == 3.8 && $RUNNER_OS == 'macos'* ]] && echo 'True' || echo 'False' )" >> $GITHUB_ENV
+          echo "DEPLOY_PYPI_SOURCE=$( [[ $PYTHON_VERSION == 3.8 && $RUNNER_OS == 'macOS' ]] && echo 'True' || echo 'False' )" >> $GITHUB_ENV
           echo "DEPLOY=$( [[ $GITHUB_EVENT_NAME == 'push' && $GITHUB_REF == 'refs/tags'* ]] && echo 'True' || echo 'False' )" >> $GITHUB_ENV
       - uses: conda-incubator/setup-miniconda@v2
         with:


### PR DESCRIPTION
Variable is now set correctly:
https://github.com/cvxgrp/diffcp/runs/4631646145?check_suite_focus=true
![image](https://user-images.githubusercontent.com/44360364/147384018-8a082007-38fc-4d4f-a195-0b11bd6f9fcd.png)

It might make sense to trigger a deploy (manually) such that the source and 3.10 wheels are on PyPI (after #49 is merged as well).

One test fails due to precision errors, which are also encountered (and fixed) in #49.