### PR TITLE
add pyproject.toml build-system

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ requires = [
     "numpy>=1.19,<1.20; python_version=='3.9'",
     "numpy>=1.21,<1.22; python_version=='3.10'",
     "scipy>=1.1.0",
+    "pybind11 >= 2.4",
     "setuptools",
     "wheel"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
     "numpy>=1.19,<1.20; python_version=='3.9'",
     "numpy>=1.21,<1.22; python_version=='3.10'",
     "scipy>=1.1.0",
-    "pybind11 >= 2.4",
+    "pybind11>=2.4",
     "setuptools",
     "wheel"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,11 @@
+[build-system]
+requires = [
+    "numpy>=1.15,<1.16; python_version=='3.6'",
+    "numpy>=1.15,<1.16; python_version=='3.7'",
+    "numpy>=1.16,<1.17; python_version=='3.8'",
+    "numpy>=1.19,<1.20; python_version=='3.9'",
+    "numpy>=1.21,<1.22; python_version=='3.10'",
+    "scipy>=1.1.0",
+    "setuptools",
+    "wheel"
+]


### PR DESCRIPTION
It is best practice to build against the oldest version of Numpy a package can work with, as binaries compiled with old Numpy versions are binary compatible with newer Numpy versions, but not vice versa. Since min numpy 1.15 is required we cannot use oldest-supported-numpy, but we use our own defined min numpy versions.

With ecos2.0.8 I'm experiencing the same as for example displayed in cvxpy/cvxpy#1367.
