### PR TITLE
fix the derivative of the projection on exponential cones

### DIFF
--- a/cpp/src/cones.cpp
+++ b/cpp/src/cones.cpp
@@ -205,7 +205,7 @@ LinearOperator _dprojection_exp(const Vector &x, bool dual) {
         // TODO(akshayka): log a warning
         s = std::abs(r);
       }
-      double l = t - x_i[2];
+      double l = rs[2] - x_i[2];
       double alpha = std::exp(r / s);
       double beta = l * r / (s * s) * alpha;
 


### PR DESCRIPTION
this fix corrects the wrong differentials reported in
https://github.com/cvxgrp/diffcp/issues/57
https://github.com/cvxgrp/diffcp/issues/58
https://github.com/cvxgrp/cvxpylayers/issues/135