### PR TITLE
refactored cone_program for solve_only

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-20.04, macos-11, windows-2022 ]
+        os: [ ubuntu-20.04, macos-12, windows-2022 ]
         python-version: [ 3.8, 3.9, "3.10", "3.11" ]
 
     env:
@@ -64,13 +64,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-20.04, macos-11, windows-2022 ]
-        python-version: [ 3.7, 3.9, "3.10", "3.11" ]
+        os: [ ubuntu-20.04, macos-12, windows-2022 ]
+        python-version: [ 3.8, 3.9, "3.10", "3.11" ]
         include:
           - os: ubuntu-20.04
             python-version: 3.8
             single_action_config: "True"
-          - os: macos-11
+          - os: macos-12
             python-version: 3.8
           - os: windows-2019
             python-version: 3.8

--- a/diffcp/cone_program.py
+++ b/diffcp/cone_program.py
@@ -146,6 +146,62 @@ def solve_and_derivative_batch(As, bs, cs, cone_dicts, n_jobs_forward=-1, n_jobs
     return xs, ys, ss, D_batch, DT_batch
 
 
+def solve_only_wrapper(A, b, c, cone_dict, warm_start, mode, kwargs):
+    """A wrapper around solve_only for the batch function"""
+    return solve_only(
+        A, b, c, cone_dict, warm_start=warm_start, mode=mode, **kwargs)
+
+
+def solve_only_batch(As, bs, cs, cone_dicts, n_jobs_forward=-1, mode="lsqr",
+                     warm_starts=None, **kwargs):
+    """
+    Solves a batch of cone programs. 
+    Uses a ThreadPool to perform operations across
+    the batch in parallel.
+
+    For more information on the arguments and return values,
+    see the docstring for `solve_and_derivative_batch` function.
+
+    This function simply contains the first half of
+    the functionality contained in `solve_and_derivative_batch`.
+    For differentiating through a cone program, this function is of no use.
+    This function exists because cvxpylayers utilizes `solve_and_derivative_batch`
+    to solve an optimization problem and populate the backward function (in PyTorch dialect)
+    during a forward pass through a cvxpylayer. However, because at inference time
+    gradient information is no longer desired, the limited functionality provided
+    by `solve_only_batch` was wanted for computational enhancements.
+    """
+    batch_size = len(As)
+    if warm_starts is None:
+        warm_starts = [None] * batch_size
+    if n_jobs_forward == -1:
+        n_jobs_forward = mp.cpu_count()
+    n_jobs_forward = min(batch_size, n_jobs_forward)
+
+    if n_jobs_forward == 1:
+        #serial
+        xs, ys, ss = [], [], []
+        for i in range(batch_size):
+            x, y, s = solve_only(As[i], bs[i], cs[i], cone_dicts[i],
+                                 warm_starts[i], mode=mode, **kwargs)
+            xs += [x]
+            ys += [y]
+            ss += [s]
+    else:
+        # thread pool
+        pool = ThreadPool(processes=n_jobs_forward)
+        args = [(A, b, c, cone_dict, warm_start, mode, kwargs) for A, b, c, cone_dict, warm_start in
+                zip(As, bs, cs, cone_dicts, warm_starts)]
+        with threadpool_limits(limits=1):
+            results = pool.starmap(solve_only_wrapper, args)
+        pool.close()
+        xs = [r[0] for r in results]
+        ys = [r[1] for r in results]
+        ss = [r[2] for r in results]
+    
+    return xs, ys, ss
+
+
 class SolverError(Exception):
     pass
 
@@ -225,7 +281,27 @@ def solve_and_derivative(A, b, c, cone_dict, warm_start=None, mode='lsqr',
     return x, y, s, D, DT
 
 
-def solve_and_derivative_internal(A, b, c, cone_dict, solve_method=None,
+def solve_only(A, b, c, cone_dict, warm_start=None, mode='lsqr',
+                         solve_method='SCS', **kwargs):
+    """
+    Solves a cone program and returns its solution.
+    
+    For more information on the arguments and return values,
+    see the docstring for `solve_and_derivative` function. However, note
+    that only x, y, and s are being returned from this function.
+
+    This is another function which was created for the benefit of cvxpylayers.
+    """
+    result = solve_internal(
+        A, b, c, cone_dict, warm_start=warm_start, mode=mode,
+        solve_method=solve_method, **kwargs)
+    x = result["x"]
+    y = result["y"]
+    s = result["s"]
+    return x, y, s    
+
+
+def solve_internal(A, b, c, cone_dict, solve_method=None,
         warm_start=None, mode='lsqr', raise_on_error=True, **kwargs):
     if mode not in ["dense", "lsqr", "lsmr"]:
         raise ValueError("Unsupported mode {}; the supported modes are "
@@ -233,17 +309,16 @@ def solve_and_derivative_internal(A, b, c, cone_dict, solve_method=None,
 
     if np.isnan(A.data).any():
         raise RuntimeError("Found a NaN in A.")
-
-    # set explicit 0s in A to np.nan
-    A.data[A.data == 0] = np.nan
-
-    # compute rows and cols of nonzeros in A
-    rows, cols = A.nonzero()
-
-    # reset np.nan entries in A to 0.0
-    A.data[np.isnan(A.data)] = 0.0
-
-    # eliminate explicit zeros in A, we no longer need them
+    
+    '''
+    TODO(quill): in solve_and_derivative_internal (sdi) there are more operations
+    on A to compute "rows" and "columns" variables. Furthermore, when
+    sdi is called, A.eliminate_zeros() is performed 2x.
+    An alternative design would be to performs op1, op2, op3 (labeled in sdi)
+    before calling solve_internal, and then return the A computed here.
+    Perhaps this is all a non-factor, but I wanted to call attention to it
+    in case this was worth changing.
+    '''
     A.eliminate_zeros()
 
     if solve_method is None:
@@ -303,10 +378,6 @@ def solve_and_derivative_internal(A, b, c, cone_dict, solve_method=None,
                 result["D"] = None
                 result["DT"] = None
                 return result
-
-        x = result["x"]
-        y = result["y"]
-        s = result["s"]
 
     elif solve_method == "ECOS":
         if warm_start is not None:
@@ -430,8 +501,6 @@ def solve_and_derivative_internal(A, b, c, cone_dict, solve_method=None,
         result["y"] = np.array(solution.z)
         result["s"] = np.array(solution.s)
 
-        x, y, s = result["x"], result["y"], result["s"]
-
         CLARABEL2SCS_STATUS_MAP = {
             "Solved": "Solved",
             "PrimalInfeasible": "Infeasible",
@@ -450,7 +519,30 @@ def solve_and_derivative_internal(A, b, c, cone_dict, solve_method=None,
         }
     else:
         raise ValueError("Solver %s not supported." % solve_method)
+    
+    return result
 
+def solve_and_derivative_internal(A, b, c, cone_dict, solve_method=None,
+        warm_start=None, mode='lsqr', raise_on_error=True, **kwargs):
+
+    result = solve_internal(A, b, c, cone_dict, solve_method=solve_method,
+        warm_start=warm_start, mode=mode, raise_on_error=raise_on_error, **kwargs)
+    x = result["x"]
+    y = result["y"]
+    s = result["s"]
+
+    # set explicit 0s in A to np.nan (op1)
+    A.data[A.data == 0] = np.nan
+
+    # compute rows and cols of nonzeros in A (op2)
+    rows, cols = A.nonzero()
+
+    # reset np.nan entries in A to 0.0 (op3)
+    A.data[np.isnan(A.data)] = 0.0
+
+    # eliminate explicit zeros in A, we no longer need them
+    A.eliminate_zeros()
+    
     # pre-compute quantities for the derivative
     m, n = A.shape
     N = m + n + 1


### PR DESCRIPTION
This PR contains the functionality requested in https://github.com/cvxpy/cvxpy/issues/2485.

All old unittests passed.
I didn’t end up writing any new unit tests since the only possible “breaking” change I made was moving code out of `solve_and_derivative_internal`, and all the unittests around that functionality still work. I also think that unittests that check the batch solve only functionality would be more easily created through cvxpylayers. 
With that being said, I’m happy to write up tests if there are suggestions for how to go about it!

Also, I hope I created the proper branch structure. I followed the contributing guide on cvxpy, creating a local `official_master` branch to track the official master branch, but making my refactors under my forked `master` branch. However, please let me know if I need adjust something!