### PR TITLE
Modernize build versioning

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,0 @@
-[bumpversion]
-current_version = 1.1.8
-files = src/diffcp/__init__.py pyproject.toml
-commit = True
-tag = True

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ on:
         branches:
             - master
         tags:
-          - '*'
+          - 'v*'
 
 # https://docs.github.com/en/actions/using-jobs/using-concurrency#example-using-a-fallback-value
 # Only cancels-in-progress on PRs (head_ref only defined in PR, fallback run_id always unique)
@@ -21,6 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # setuptools-scm needs tags to compute the version
 
       - uses: actions/setup-python@v5
         with:
@@ -45,6 +47,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # setuptools-scm needs tags to compute the version
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.22.0
@@ -64,6 +68,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # setuptools-scm needs tags to compute the version
 
       - name: Build sdist
         run: pipx run build --sdist
@@ -80,7 +86,7 @@ jobs:
     environment: pypi
     permissions:
       id-token: write
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     steps:
       - uses: actions/download-artifact@v4
         with:
@@ -101,4 +107,3 @@ jobs:
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:
           verbose: true
-          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ share/python-wheels/
 .installed.cfg
 *.egg
 MANIFEST
+src/diffcp/_version.py
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,8 +20,10 @@ python_add_library(_diffcp MODULE cpp/src/wrapper.cpp cpp/src/deriv.cpp cpp/src/
 target_link_libraries(_diffcp PRIVATE pybind11::headers)
 target_include_directories(_diffcp PRIVATE cpp/external/eigen/)
 target_include_directories(_diffcp PRIVATE cpp/include/)
-
-
+set_target_properties(_diffcp PROPERTIES
+  CXX_STANDARD 11
+  CXX_STANDARD_REQUIRED ON
+  CXX_EXTENSIONS OFF)
 
 # This is passing in the version as a define just as an example
 target_compile_definitions(_diffcp PRIVATE VERSION_INFO=${PROJECT_VERSION})

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,2 @@
 develop:
-	rm -f *.so
-	python setup.py clean --all
-	python setup.py develop
+	uv sync --extra test

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,14 +1,16 @@
 
 [project]
 name = "diffcp"
-version = "1.1.8"
+dynamic = ["version"]
 description = "A library to compute gradients for convex optimization problems"
 requires-python = ">= 3.10"
 
 readme = "README.md"
 
 dependencies = [
-    "cvxpy>=1.6.3",
+    "numpy >= 2.0",
+    "scipy >= 1.10",
+    "scs >= 3.0.0",
     "threadpoolctl >= 1.1",
 ]
 urls = {Homepage = "https://github.com/cvxgrp/diffcp/"}
@@ -17,13 +19,24 @@ license = {text = "Apache License, Version 2.0"}
 [build-system]
 requires = [
     "scikit-build-core",
+    "setuptools-scm >= 8",
     "pybind11>=2.4",
 ]
 build-backend = "scikit_build_core.build"
 
 [project.optional-dependencies]
+cvxpy = [
+    "cvxpy >= 1.6.3",
+]
+clarabel = [
+    "clarabel >= 0.5.1",
+]
+ecos = [
+    "ecos >= 2.0.10",
+]
 test = [
     "clarabel >= 0.5.1",
+    "cvxpy >= 1.6.3",
     "scs >= 3.0.0",
     "pytest>=8.3.5",
     "ecos >= 2.0.10",
@@ -33,3 +46,16 @@ test = [
 wheel.expand-macos-universal-tags = true
 wheel.packages = ["src/diffcp"]
 
+[tool.scikit-build.sdist]
+include = ["src/diffcp/_version.py"]
+
+[tool.scikit-build.metadata.version]
+provider = "scikit_build_core.metadata.setuptools_scm"
+
+[tool.setuptools_scm]
+version_file = "src/diffcp/_version.py"
+version_scheme = "semver-pep440-release-branch"
+fallback_version = "0.0.0"
+
+[tool.setuptools_scm.scm.git]
+describe_command = ["git", "describe", "--dirty", "--tags", "--long", "--match", "v*"]

--- a/src/diffcp/__init__.py
+++ b/src/diffcp/__init__.py
@@ -1,4 +1,12 @@
-__version__ = "1.1.8"
+try:
+    from diffcp._version import version as __version__
+except ImportError:
+    from importlib.metadata import PackageNotFoundError, version
+
+    try:
+        __version__ = version("diffcp")
+    except PackageNotFoundError:
+        __version__ = "0.0.0+unknown"
 
 from diffcp.cone_program import solve_and_derivative, \
     solve_and_derivative_batch, \


### PR DESCRIPTION
## Description

Modernizes the build/versioning setup along the same lines as cvxpy/cvxpy#3331:

- derive package versions from git tags with setuptools-scm
- generate diffcp._version at build time and re-export it as diffcp.__version__
- remove the stale .bumpversion.cfg release/version bump workflow
- fetch full git history in CI checkout steps so tags are available to setuptools-scm
- replace the stale setup.py develop Makefile target with a uv workflow
- move cvxpy out of runtime dependencies and into optional/test dependencies to avoid the circular dependency
- declare direct runtime dependencies (numpy, scipy, scs, threadpoolctl) instead of relying on cvxpy transitively
- explicitly compile the C++ extension as C++11 to avoid depending on newer compiler defaults

## Verification

- uv build
- uv run python -c 'import diffcp; print(diffcp.__version__)'
- uv run --extra test pytest tests/ -q (43 passed, 2 warnings)